### PR TITLE
feat: detect subtests 

### DIFF
--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -134,6 +134,16 @@ end
 ---@async
 ---@return neotest.Tree| nil
 function adapter.discover_positions(path)
+  -- NOTE: this is a query to annotate a test function as a namespace
+  -- ((function_declaration
+  --   name: (identifier) @namespace.name
+  --   body: (block
+  --     (call_expression
+  --       function: (selector_expression
+  --         field: (field_identifier) @_method)
+  --   (#match? @_method "^Run"))))
+  --   (#match? @namespace.name "^Test"))
+  --   @namespace.definition
   local query = [[
     ((function_declaration
       name: (identifier) @test.name)

--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -186,7 +186,7 @@ end
 ---@return string
 local function get_prefix(tree, name)
   local parent_tree = tree:parent()
-  if not parent_tree then
+  if not parent_tree or parent_tree:data().type == 'file' then
     return name
   end
   local parent_name = parent_tree:data().name
@@ -251,7 +251,7 @@ function adapter.results(_, result, tree)
         output = empty_result_fname,
       }
     else
-      local id_parts = vim.split(value.id, "::")
+      local id_parts = vim.split(value.id, '::')
       table.remove(id_parts, 1)
       local test_output = tests[table.concat(id_parts, '/')]
       if test_output then

--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -192,7 +192,7 @@ function adapter.build_spec(args)
   end
 
   return {
-    command = command,
+    command = table.concat(command, ' '),
     context = {
       results_path = results_path,
       file = position.path,

--- a/neotest_go/cases.go
+++ b/neotest_go/cases.go
@@ -1,5 +1,9 @@
 package main
 
-func doesAThing(a, b int) int {
+func add(a, b int) int {
 	return a + b
+}
+
+func subtract(a, b int) int {
+	return a - b
 }

--- a/neotest_go/cases.go
+++ b/neotest_go/cases.go
@@ -1,0 +1,5 @@
+package main
+
+func doesAThing(a, b int) int {
+	return a + b
+}

--- a/neotest_go/cases_test.go
+++ b/neotest_go/cases_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDoesAThing(t *testing.T) {
+func TestSubtract(t *testing.T) {
 	testCases := []struct {
 		desc string
 		a    int
@@ -28,22 +28,22 @@ func TestDoesAThing(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			assert.Equal(t, tC.want, doesAThing(tC.a, tC.b))
+			assert.Equal(t, tC.want, subtract(tC.a, tC.b))
 		})
 	}
 }
 
-func TestDoesAThingAnotherWay(t *testing.T) {
+func TestAdd(t *testing.T) {
 	t.Run("test one", func(t *testing.T) {
-		assert.Equal(t, 3, doesAThing(1, 2))
+		assert.Equal(t, 3, add(1, 2))
 	})
 
 	t.Run("test two", func(t *testing.T) {
-		assert.Equal(t, 5, doesAThing(1, 2))
+		assert.Equal(t, 5, add(1, 2))
 	})
 
 	variable := "string"
 	t.Run(variable, func(t *testing.T) {
-		assert.Equal(t, 3, doesAThing(1, 2))
+		assert.Equal(t, 3, add(1, 2))
 	})
 }

--- a/neotest_go/cases_test.go
+++ b/neotest_go/cases_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoesAThing(t *testing.T) {
+	testCases := []struct {
+		desc string
+		a    int
+		b    int
+		want int
+	}{
+		{
+			desc: "test one",
+			a:    1,
+			b:    2,
+			want: 3,
+		},
+		{
+			desc: "test two",
+			a:    1,
+			b:    2,
+			want: 7,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			assert.Equal(t, tC.want, doesAThing(tC.a, tC.b))
+		})
+	}
+}
+
+func TestDoesAThingAnotherWay(t *testing.T) {
+	t.Run("test one", func(t *testing.T) {
+		assert.Equal(t, 3, doesAThing(1, 2))
+	})
+
+	t.Run("test two", func(t *testing.T) {
+		assert.Equal(t, 5, doesAThing(1, 2))
+	})
+
+	variable := "string"
+	t.Run(variable, func(t *testing.T) {
+		assert.Equal(t, 3, doesAThing(1, 2))
+	})
+}


### PR DESCRIPTION
This PR adds a query that will allow subtests declared using `t.Run` to be detected and run (?separately).

# TODO
- [x] The correct test command is not run for these tests currently

@rcarriga I'm trying to get subtests like the example in this PR working
```go

func TestDoesAThingAnotherWay(t *testing.T) {
	t.Run("test one", func(t *testing.T) {
		assert.Equal(t, 3, doesAThing(1, 2))
	})

	t.Run("test two", func(t *testing.T) {
		assert.Equal(t, 5, doesAThing(1, 2))
	})

	variable := "string"
	t.Run(variable, func(t *testing.T) {
		assert.Equal(t, 3, doesAThing(1, 2))
	})
}
```

But whilst my query detects these correctly and they show signs and I can run the nearest the output from the test runner shows that it's not running the same command as I'm expecting. I verified that the command generated works in the terminal but with my cursor on one of those tests and running the `run.run` funciton despite the command created being the right one the output seems to show like some other command was run since it doesn't match the terminal output